### PR TITLE
尝试修正sessionToken验证失效问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const plugin = new KiviPlugin('ChatGPT', version)
 
 const config = {
   // sessionToken
-  sessionToken: '',
+  email: '',
+  password: '',
   // 命令前缀
   cmdPrefix: '%'
 }
@@ -25,19 +26,22 @@ plugin.onMounted(async bot => {
   Object.assign(config, plugin.loadConfig())
   plugin.saveConfig(config)
 
-  if (!config.sessionToken) {
+  if (!config.email || !config.password) {
     bot.sendPrivateMsg(plugin.mainAdmin, msgs.needConfig)
     plugin.throwPluginError(msgs.needConfig)
     return
   }
 
-  const { ChatGPTAPI } = await import('chatgpt')
+  const { ChatGPTAPI, getOpenAIAuth } = await import('chatgpt')
+
+  const openAIAuth = await getOpenAIAuth({
+    email: config.email,
+    password: config.password
+  })
 
   const api = new ChatGPTAPI({
-    markdown: true,
-    sessionToken: config.sessionToken,
-    userAgent: ChromeUA,
-    accessTokenTTL: 60 * 1000
+    ...openAIAuth,
+    markdown: true
   })
 
   try {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@kivibot/core": "latest"
   },
   "dependencies": {
-    "chatgpt": "^2.0.4"
+    "chatgpt": "^2.3.0",
+    "puppeteer": "^19.4.0"
   }
 }


### PR DESCRIPTION
**未经测试验证**
此前未使用过kivibot，猜测可能是直接引用npm包，需要作者更新代码提交后进行测试
根据chatgpt-api 22-12-12更新提供了新的e-mail，password方式，更新chatgpt-api依赖与验证代码
https://github.com/transitive-bullshit/chatgpt-api

目前openAI对请求添加了新的Cloudflare保护，但是同时添加了API keys，可以直接通过包裹api-keys的请求进行访问
如果chatgpt-api失效可以尝试直接发送请求